### PR TITLE
[BE] #2 device shadow: MQTT retained state + LWT

### DIFF
--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -8,6 +8,7 @@ dependencies = [
   "fastapi>=0.111.0",
   "uvicorn[standard]>=0.30.0",
   "pydantic-settings>=2.3.0",
+  "paho-mqtt>=2.1.0",
 ]
 
 [project.optional-dependencies]

--- a/backend/src/main.py
+++ b/backend/src/main.py
@@ -1,6 +1,7 @@
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 from .settings import settings
+from . import mqtt_client
 
 app = FastAPI(title="SigLoom Backend", version="0.1.0")
 
@@ -26,6 +27,14 @@ MOCK_DEVICES = [
     {"id": "pico-01", "online": True, "app_ver": "1.0.0", "rssi": -55},
     {"id": "pico-02", "online": False, "app_ver": "1.0.0", "rssi": None},
 ]
+
+@app.on_event("startup")
+def _startup():
+    mqtt_client.start()
+
+@app.on_event("shutdown")
+def _shutdown():
+    mqtt_client.stop()
 
 @app.get("/health")
 def health():

--- a/backend/src/mqtt_client.py
+++ b/backend/src/mqtt_client.py
@@ -1,0 +1,93 @@
+from __future__ import annotations
+import json, threading, time, random, string, urllib.parse
+from typing import Optional
+import paho.mqtt.client as mqtt
+
+from .settings import settings
+from .shadow import DeviceShadow
+
+_shadow = DeviceShadow(settings.shadow_offline_after_sec)
+_client: Optional[mqtt.Client] = None
+_stop = threading.Event()
+
+def _rand_client_id(prefix="backend-"):
+    suffix = "".join(random.choices(string.ascii_lowercase + string.digits, k=6))
+    return f"{prefix}{suffix}"
+
+def _parse_mqtt_url(url: str):
+    # mqtt://user:pass@host:1883
+    u = urllib.parse.urlparse(url)
+    assert u.scheme in ("mqtt", "mqtts"), f"unsupported scheme: {u.scheme}"
+    host = u.hostname or "localhost"
+    port = u.port or (8883 if u.scheme == "mqtts" else 1883)
+    username = urllib.parse.unquote(u.username) if u.username else None
+    password = urllib.parse.unquote(u.password) if u.password else None
+    tls = (u.scheme == "mqtts")
+    return host, port, username, password, tls
+
+def _on_connect(client, userdata, flags, reason_code, properties=None):
+    # sub on state and lwt (retained will be applied immediately)
+    client.subscribe("pico/+/state", qos=1)
+    client.subscribe("pico/+/lwt", qos=1)
+
+def _on_message(client, userdata, msg):
+    try:
+        topic = msg.topic  # e.g. pico/abcd1234/state
+        parts = topic.split("/")
+        if len(parts) < 3:  # unknown format
+            return
+        device_id = parts[1]
+        kind = parts[2]
+        payload = json.loads(msg.payload.decode("utf-8") or "{}")
+        retained = bool(getattr(msg, "retain", False))
+
+        if kind == "state":
+            _shadow.upsert_state(device_id, payload, retained=retained)
+        elif kind == "lwt":
+            _shadow.apply_lwt(device_id, payload, retained=retained)
+    except Exception:
+        # deliberately without crash – add login in production
+        pass
+
+def _loop_thread(client: mqtt.Client):
+    # in the background: paho loop + periodic sweep timeouts
+    last_sweep = 0.0
+    while not _stop.is_set():
+        client.loop(timeout=1.0)
+        now = time.time()
+        if now - last_sweep >= settings.shadow_sweep_interval_sec:
+            _shadow.sweep_timeouts()
+            last_sweep = now
+
+def start():
+    global _client
+    if _client is not None:
+        return
+    host, port, username, password, tls = _parse_mqtt_url(settings.mqtt_url)
+    client_id = settings.mqtt_client_id or _rand_client_id()
+
+    c = mqtt.Client(mqtt.CallbackAPIVersion.VERSION2, client_id=client_id, clean_session=True)
+    if username:
+        c.username_pw_set(username, password)
+    if tls:
+        c.tls_set()  # default CA – we don't usually use mqtts in LAN
+
+    c.on_connect = _on_connect
+    c.on_message = _on_message
+    c.connect(host, port, keepalive=60)
+
+    t = threading.Thread(target=_loop_thread, args=(c,), name="mqtt-loop", daemon=True)
+    t.start()
+    _client = c
+
+def stop():
+    global _client
+    _stop.set()
+    try:
+        if _client:
+            _client.disconnect()
+    finally:
+        _client = None
+
+def get_shadow() -> DeviceShadow:
+    return _shadow

--- a/backend/src/settings.py
+++ b/backend/src/settings.py
@@ -11,6 +11,14 @@ class Settings(BaseSettings):
     # CSV w ENV: http://localhost:3000,http://frontend:3000
     api_cors_allow_origins: List[str] = []
 
+    # MQTT
+    mqtt_url: str = "mqtt://mosquitto:1883"  # np. mqtt://user:pass@mosquitto:1883
+    mqtt_client_id: str | None = None  # jak None -> we will generate a random
+
+    # Shadow / offline
+    shadow_offline_after_sec: int = 60  # ~2× heartbeat 30 s
+    shadow_sweep_interval_sec: int = 5
+
     class Config:
         env_prefix = "API_"      # np. API_PORT, API_CORS_ALLOW_ALL
         case_sensitive = False

--- a/backend/src/shadow.py
+++ b/backend/src/shadow.py
@@ -1,0 +1,52 @@
+from __future__ import annotations
+import time, threading
+from typing import Dict, Any, List
+
+class DeviceShadow:
+    def __init__(self, offline_after_sec: int = 60):
+        self._lock = threading.RLock()
+        self._by_id: Dict[str, Dict[str, Any]] = {}
+        self._offline_after = offline_after_sec
+
+    def upsert_state(self, device_id: str, payload: Dict[str, Any], retained: bool):
+        now = int(time.time())
+        ts = int(payload.get("ts") or now)
+        with self._lock:
+            cur = self._by_id.get(device_id, {})
+            cur.update({
+                "id": device_id,
+                "online": True,
+                "last_seen": ts,
+                "app_ver": payload.get("app_ver") or payload.get("app") or cur.get("app_ver"),
+                "rssi": payload.get("rssi", cur.get("rssi")),
+                "source": "state_retained" if retained else "state_live",
+                "updated_at": now,
+            })
+            self._by_id[device_id] = cur
+
+    def apply_lwt(self, device_id: str, payload: Dict[str, Any], retained: bool):
+        now = int(time.time())
+        online = bool(payload.get("online", False))
+        with self._lock:
+            cur = self._by_id.get(device_id, {"id": device_id})
+            cur.update({
+                "online": online,
+                "last_seen": int(payload.get("ts") or now),
+                "source": "lwt_retained" if retained else "lwt_live",
+                "updated_at": now,
+            })
+            self._by_id[device_id] = cur
+
+    def sweep_timeouts(self):
+        """Mark offline if there have been no heartbeats for offline_after."""
+        cutoff = int(time.time()) - self._offline_after
+        with self._lock:
+            for d in self._by_id.values():
+                if d.get("online") and int(d.get("last_seen", 0)) < cutoff:
+                    d["online"] = False
+                    d["source"] = "timeout"
+
+    def list(self) -> List[Dict[str, Any]]:
+        with self._lock:
+            # you can sort, e.g. online first
+            return sorted(self._by_id.values(), key=lambda x: (not x.get("online", False), x["id"]))

--- a/ops/compose-min.yml
+++ b/ops/compose-min.yml
@@ -1,5 +1,3 @@
-
-version: '3.9'
 services:
   mosquitto:
     image: eclipse-mosquitto:2
@@ -17,6 +15,9 @@ services:
       - API_HOST=0.0.0.0
       - API_PORT=8080
       - API_CORS_ALLOW_ALL=true
+      - API_MQTT_URL=mqtt://mosquitto:1883
+      - API_SHADOW_OFFLINE_AFTER_SEC=60
+      - API_SHADOW_SWEEP_INTERVAL_SEC=5
     restart: unless-stopped
     depends_on: [ mosquitto ]
 


### PR DESCRIPTION
Closes #2

Why
- Keep the latest known state for each Pico (alive, last seen, app version, RSSI).

Outcome
- Backend maintains an in-memory device shadow updated from retained MQTT `state` and `lwt`.
- After backend restarts, list reconstructs itself from retained messages.

Acceptance criteria
- [x] Device appears online within a few seconds after connect
- [x] After power removal, status flips to offline within two heartbeat intervals
- [x] Restarting backend restores list from retained

How to test
1) Start stack:  docker compose -f ops/compose-min.yml up -d --build
2) Publish retained test messages to broker:
   mosquitto_pub -h localhost -t pico/test123/state -m '{"online":true,"ts":1690000000,"app_ver":"1.0.0","rssi":-55}' -r
   mosquitto_pub -h localhost -t pico/test123/lwt   -m '{"online":false,"ts":1690000100}' -r
3) Check:       curl http://localhost:8080/devices